### PR TITLE
Check pipette property

### DIFF
--- a/plugins/pipette/src/pipette.cc
+++ b/plugins/pipette/src/pipette.cc
@@ -61,7 +61,7 @@ void PipetteHandler::computeValues(ViewInterface::Ptr view,
   PresentationInterface::Ptr presentation = view->getCurrentPresentation();
   auto pipette =
       boost::dynamic_pointer_cast<PipetteViewInterface>(presentation);
-  if (pipette == nullptr) {
+  if (pipette == nullptr || !presentation->isPropertyDefined(PIPETTE_PROPERTY_NAME)) {
     printf("PANIC: Presentation does not implement PipetteViewInterface!\n");
     gdk_threads_enter();
     view->setStatusMessage("Pipette is not supported for this presentation.");


### PR DESCRIPTION
This prevents the segfault from happening for grayscale tiffs. Effectively we're now both checking if a presentation implements the required interface and whether it defines this property.