### PR TITLE
Change SLI window title to file path

### DIFF
--- a/plugins/sep/sli/slipresentation.cc
+++ b/plugins/sep/sli/slipresentation.cc
@@ -33,6 +33,7 @@ SliPresentation::create(ScroomInterface::Ptr scroomInterface_) {
 SliPresentation::~SliPresentation() {}
 
 bool SliPresentation::load(const std::string &fileName) {
+  filepath = fileName;
   if (!parseSli(fileName)) {
     return false;
   }
@@ -239,7 +240,7 @@ bool SliPresentation::isPropertyDefined(const std::string &name) {
   return properties.end() != properties.find(name);
 }
 
-std::string SliPresentation::getTitle() { return "slipresentation"; }
+std::string SliPresentation::getTitle() { return filepath; }
 
 ////////////////////////////////////////////////////////////////////////
 // PresentationBase

--- a/plugins/sep/sli/slipresentation.hh
+++ b/plugins/sep/sli/slipresentation.hh
@@ -57,6 +57,9 @@ private:
   /** (Optional) the object used to draw the varnish overlay */
   Varnish::Ptr varnish;
 
+  /** The absolute path to the SLI file */
+  std::string filepath;
+
 private:
   /** Constructor */
   SliPresentation(ScroomInterface::Ptr scroomInterface);

--- a/plugins/sep/test/slipresentation-tests.cc
+++ b/plugins/sep/test/slipresentation-tests.cc
@@ -88,7 +88,9 @@ BOOST_AUTO_TEST_CASE(slipresentation_load_sli_xoffset) {
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_presentationinterface_inherited) {
+  std::string testFilePath = testFileDir + "sli_xoffset.sli";
   SliPresentation::Ptr presentation = createPresentation();
+  presentation->load(testFileDir);
 
   std::string nameStr = "testname";
   std::string valueStr;
@@ -103,7 +105,7 @@ BOOST_AUTO_TEST_CASE(slipresentation_presentationinterface_inherited) {
   BOOST_REQUIRE(presentation->getProperty(nameStr, valueStr) == true);
   BOOST_REQUIRE(valueStr == "testvalue");
 
-  BOOST_REQUIRE(presentation->getTitle() == "slipresentation");
+  BOOST_REQUIRE(presentation->getTitle() == testFileDir);
 
   presentation.reset();
 }


### PR DESCRIPTION
Show the file path of the SLI file in the title of the window.

Fixes [this](https://gitlab.com/sep-group-2/scroom-plugin-cpp/-/issues/3) issue