### PR TITLE
Faster SLI redraw with partial reductions 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,9 +34,9 @@ plugins_sep_src_libspsep_la_SOURCES = \
 	plugins/sep/varnish/varnish.cc \
 	plugins/sep/varnish/varnish.hh
 
-plugins_sep_src_libspsep_la_LIBADD = @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff
+plugins_sep_src_libspsep_la_LIBADD = @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff -ldl -lpthread
 
-plugins_sep_src_libspsep_la_LDFLAGS = $(loadflag) -I../scroom/gui/src/
+plugins_sep_src_libspsep_la_LDFLAGS = $(loadflag) -I../scroom/gui/src/ -pthread
 
 if BOOST_UNITTESTS
 
@@ -61,7 +61,7 @@ plugins_sep_test_sep_tests_SOURCES = \
 	plugins/sep/test/sep-tests.cc
 
 plugins_sep_test_sep_tests_LDADD = \
-	@BOOSTTESTLIB@ @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff -ldl \
+	@BOOSTTESTLIB@ @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff -ldl -lpthread \
 	plugins/sep/src/libspsep.la \
 	plugins/sep/*.lo \
 	plugins/sep/sli/*.lo \

--- a/plugins/pipette/src/pipette.cc
+++ b/plugins/pipette/src/pipette.cc
@@ -61,7 +61,8 @@ void PipetteHandler::computeValues(ViewInterface::Ptr view,
   PresentationInterface::Ptr presentation = view->getCurrentPresentation();
   auto pipette =
       boost::dynamic_pointer_cast<PipetteViewInterface>(presentation);
-  if (pipette == nullptr || !presentation->isPropertyDefined(PIPETTE_PROPERTY_NAME)) {
+  if (pipette == nullptr ||
+      !presentation->isPropertyDefined(PIPETTE_PROPERTY_NAME)) {
     printf("PANIC: Presentation does not implement PipetteViewInterface!\n");
     gdk_threads_enter();
     view->setStatusMessage("Pipette is not supported for this presentation.");

--- a/plugins/sep/sli/sli-helpers.cc
+++ b/plugins/sep/sli/sli-helpers.cc
@@ -129,6 +129,43 @@ spannedRectangle(boost::dynamic_bitset<> bitmap,
   return rect;
 }
 
+int findBestSegFit(unsigned int nSegments, unsigned int height)
+{
+  int i = 1;
+  while (i * nSegments <= height)
+  {
+    if (i * 2 * nSegments <= height)
+    {
+      i *= 2;
+      continue;
+    }
+
+    break;
+  }
+
+  return i;
+}
+
+boost::dynamic_bitset<> halfSegBitmask(boost::dynamic_bitset<> toggledSegments)
+{
+  auto nSegments = toggledSegments.size();
+  int first = -1, last = -1;
+  boost::dynamic_bitset<> bitmask {nSegments};
+  for (unsigned int i = 0; i < nSegments; i++)
+  {
+    if (toggledSegments[i] && first == -1)
+      first = (int)i;
+
+    if(toggledSegments[i])
+      last = (int)i;
+  }
+
+  for (unsigned int i = first; i < first + (unsigned int)((last-first)/2); i++)
+    bitmask.set(i);
+
+  return bitmask;
+}
+
 SurfaceWrapper::~SurfaceWrapper() {
   if (!empty) {
     free(cairo_image_surface_get_data(surface));

--- a/plugins/sep/sli/sli-helpers.cc
+++ b/plugins/sep/sli/sli-helpers.cc
@@ -130,17 +130,8 @@ spannedRectangle(boost::dynamic_bitset<> bitmap,
 }
 
 int findBestSegFit(unsigned int nSegments, unsigned int height) {
-  int i = 1;
-  while (i * nSegments <= height) {
-    if (i * 2 * nSegments <= height) {
-      i *= 2;
-      continue;
-    }
-
-    break;
-  }
-
-  return i;
+  int k = std::log2(height/nSegments);
+  return static_cast<int>(std::pow(2, k));
 }
 
 boost::dynamic_bitset<>

--- a/plugins/sep/sli/sli-helpers.cc
+++ b/plugins/sep/sli/sli-helpers.cc
@@ -129,13 +129,10 @@ spannedRectangle(boost::dynamic_bitset<> bitmap,
   return rect;
 }
 
-int findBestSegFit(unsigned int nSegments, unsigned int height)
-{
+int findBestSegFit(unsigned int nSegments, unsigned int height) {
   int i = 1;
-  while (i * nSegments <= height)
-  {
-    if (i * 2 * nSegments <= height)
-    {
+  while (i * nSegments <= height) {
+    if (i * 2 * nSegments <= height) {
       i *= 2;
       continue;
     }
@@ -146,21 +143,21 @@ int findBestSegFit(unsigned int nSegments, unsigned int height)
   return i;
 }
 
-boost::dynamic_bitset<> halfSegBitmask(boost::dynamic_bitset<> toggledSegments)
-{
+boost::dynamic_bitset<>
+halfSegBitmask(boost::dynamic_bitset<> toggledSegments) {
   auto nSegments = toggledSegments.size();
   int first = -1, last = -1;
-  boost::dynamic_bitset<> bitmask {nSegments};
-  for (unsigned int i = 0; i < nSegments; i++)
-  {
+  boost::dynamic_bitset<> bitmask{nSegments};
+  for (unsigned int i = 0; i < nSegments; i++) {
     if (toggledSegments[i] && first == -1)
       first = (int)i;
 
-    if(toggledSegments[i])
+    if (toggledSegments[i])
       last = (int)i;
   }
 
-  for (unsigned int i = first; i < first + (unsigned int)((last-first)/2); i++)
+  for (unsigned int i = first; i < first + (unsigned int)((last - first) / 2);
+       i++)
     bitmask.set(i);
 
   return bitmask;

--- a/plugins/sep/sli/sli-helpers.hh
+++ b/plugins/sep/sli/sli-helpers.hh
@@ -84,3 +84,14 @@ int pointToOffset(Scroom::Utils::Rectangle<int> rect,
 Scroom::Utils::Rectangle<int>
 spannedRectangle(boost::dynamic_bitset<> bitmap,
                  std::vector<SliLayer::Ptr> layers, bool fromOrigin = false);
+
+/**
+ * Finds the multiple of 2 whose size best approximates splitting @param height
+ * into @param nSegments segments.
+ */
+int findBestSegFit(unsigned int nSegments, unsigned int height);
+
+/**
+ * Returns a bitmask that divides the @param toggledSegments bitamp in half.
+ */
+boost::dynamic_bitset<> halfSegBitmask(boost::dynamic_bitset<> toggledSegments);

--- a/plugins/sep/sli/slicontrolpanel.cc
+++ b/plugins/sep/sli/slicontrolpanel.cc
@@ -75,8 +75,7 @@ void toggle_and_redraw(double old_value, double new_value, double other_value,
   }
 
   presPtr->setToggled(toggled);
-  presPtr->wipeCache();
-  presPtr->triggerRedraw();
+  presPtr->wipeCacheAndRedraw();
 }
 
 /* Update the Tree Model according to the new sliders' bounds */
@@ -185,8 +184,7 @@ void on_toggle(GtkCellRendererToggle *renderer, gchar *path,
     cPanel->lastFocused = TREEVIEW;
     toggled.set(atoi(path));
     presPtr->setToggled(toggled);
-    presPtr->wipeCache();
-    presPtr->triggerRedraw();
+    presPtr->wipeCacheAndRedraw();
   }
 }
 

--- a/plugins/sep/sli/slipresentation.cc
+++ b/plugins/sep/sli/slipresentation.cc
@@ -37,6 +37,7 @@ bool SliPresentation::load(const std::string &fileName) {
   if (!parseSli(fileName)) {
     return false;
   }
+  properties[PIPETTE_PROPERTY_NAME] = "";
   source->visible.resize(source->layers.size(), false);
   source->toggled.resize(source->layers.size(), true);
   source->computeHeightWidth();
@@ -150,7 +151,7 @@ bool SliPresentation::parseSli(const std::string &sliFileName) {
 ////////////////////////////////////////////////////////////////////////
 // SliPresentationInterface
 
-void SliPresentation::wipeCache() { source->wipeCache(); }
+void SliPresentation::wipeCacheAndRedraw() { source->wipeCacheAndRedraw(); }
 
 void SliPresentation::triggerRedraw() {
   for (ViewInterface::WeakPtr view : views) {

--- a/plugins/sep/sli/slipresentation.hh
+++ b/plugins/sep/sli/slipresentation.hh
@@ -91,10 +91,10 @@ public:
   ////////////////////////////////////////////////////////////////////////
 
   /**
-   *  Erase (delete reference) the RGB cache of the SliSource except for the
-   * bottom layer for which the relevant bytes are simply turned to 0s.
+   * Clear (ie write 0s) the area of the bottom surface intersecting with the
+   * toggled layers and trigger a redraw.
    */
-  void wipeCache() override;
+  void wipeCacheAndRedraw() override;
 
   /** Causes the SliPresentation to redraw the current presentation */
   void triggerRedraw() override;

--- a/plugins/sep/sli/slipresentationinterface.hh
+++ b/plugins/sep/sli/slipresentationinterface.hh
@@ -12,10 +12,10 @@ public:
   virtual ~SliPresentationInterface() {}
 
   /**
-   *  Erase the RGB cache of the SliSource except for the bottom layer
-   *  for which the relevant bytes are simply turned to 0s.
+   * Clear (ie write 0s) the area of the bottom surface intersecting with the
+   * toggled layers and trigger a redraw.
    */
-  virtual void wipeCache() = 0;
+  virtual void wipeCacheAndRedraw() = 0;
 
   /** Causes the SliPresentation to redraw the current presentation */
   virtual void triggerRedraw() = 0;

--- a/plugins/sep/sli/slisource.cc
+++ b/plugins/sep/sli/slisource.cc
@@ -80,9 +80,7 @@ void SliSource::queryImportBitmaps() {
       PRIO_HIGHER, threadQueue);
 }
 
-void SliSource::wipeCache() {
-  clearBottomSurface();
-}
+void SliSource::wipeCache() { clearBottomSurface(); }
 
 SurfaceWrapper::Ptr SliSource::getSurface(int zoom) {
   if (!bitmapsImported) {
@@ -104,17 +102,15 @@ void SliSource::fillCache() {
   disableInteractions();
   visible ^= toggled;
 
-  if (!rgbCache.count(0) || rgbCache[0]->clear)
-  {
+  if (!rgbCache.count(0) || rgbCache[0]->clear) {
     computeRgb();
 
-    for (int i = -1; i >= -30; i--)
-    {
+    for (int i = -1; i >= -30; i--) {
       // true -> uses multithreading
       reduceRgb(i, true);
     }
   }
-  
+
   rgbCache[0]->clear = false;
   toggled.reset();
   enableInteractions();
@@ -122,10 +118,10 @@ void SliSource::fillCache() {
   triggerRedraw();
 }
 
-void SliSource::reduceSegments(SurfaceWrapper::Ptr targetSurface, boost::dynamic_bitset<> toggledSegments,
-                              int baseSegHeight, int zoom) {
-  for (int i = 0; i < (int)toggledSegments.size(); i++)
-  {
+void SliSource::reduceSegments(SurfaceWrapper::Ptr targetSurface,
+                               boost::dynamic_bitset<> toggledSegments,
+                               int baseSegHeight, int zoom) {
+  for (int i = 0; i < (int)toggledSegments.size(); i++) {
     if (!toggledSegments[i])
       continue;
 
@@ -134,33 +130,38 @@ void SliSource::reduceSegments(SurfaceWrapper::Ptr targetSurface, boost::dynamic
     const int sourceStride = rgbCache[zoom + 1]->getStride();
 
     int targetSegHeight;
-    if (i == (int)toggledSegments.size() - 1)
-    {
+    if (i == (int)toggledSegments.size() - 1) {
       // the last segment will probably have leftover pixels
       int leftoverPixels = (total_height % baseSegHeight) / pow(2, -zoom);
       targetSegHeight = (baseSegHeight / pow(2, -zoom)) + leftoverPixels;
-    }
-    else
-    {
+    } else {
       targetSegHeight = baseSegHeight / pow(2, -zoom);
     }
 
     const int targetWidth = sourceWidth / 2;
     const int targetOffset = (baseSegHeight / pow(2, -zoom)) * i;
     auto targetStride = targetSurface->getStride();
-    auto targetBitmap = targetSurface->getBitmap() + targetOffset * targetStride;
+    auto targetBitmap =
+        targetSurface->getBitmap() + targetOffset * targetStride;
 
-    for (int y = 0; y < targetSegHeight; y++)
-    {
-      auto sourceBitmap1 = rgbCache[zoom + 1]->getBitmap() + 2*y*sourceStride + sourceOffset*sourceStride;
+    for (int y = 0; y < targetSegHeight; y++) {
+      auto sourceBitmap1 = rgbCache[zoom + 1]->getBitmap() +
+                           2 * y * sourceStride + sourceOffset * sourceStride;
       auto sourceBitmap2 = sourceBitmap1 + sourceStride;
 
-      for (int x = 0; x < targetWidth; x++)
-      {
-        targetBitmap[0] = (sourceBitmap1[0] + sourceBitmap1[4] + sourceBitmap2[0] + sourceBitmap2[4]) / 4;
-        targetBitmap[1] = (sourceBitmap1[1] + sourceBitmap1[5] + sourceBitmap2[1] + sourceBitmap2[5]) / 4;
-        targetBitmap[2] = (sourceBitmap1[2] + sourceBitmap1[6] + sourceBitmap2[2] + sourceBitmap2[6]) / 4;
-        targetBitmap[3] = (sourceBitmap1[3] + sourceBitmap1[7] + sourceBitmap2[3] + sourceBitmap2[7]) / 4;
+      for (int x = 0; x < targetWidth; x++) {
+        targetBitmap[0] = (sourceBitmap1[0] + sourceBitmap1[4] +
+                           sourceBitmap2[0] + sourceBitmap2[4]) /
+                          4;
+        targetBitmap[1] = (sourceBitmap1[1] + sourceBitmap1[5] +
+                           sourceBitmap2[1] + sourceBitmap2[5]) /
+                          4;
+        targetBitmap[2] = (sourceBitmap1[2] + sourceBitmap1[6] +
+                           sourceBitmap2[2] + sourceBitmap2[6]) /
+                          4;
+        targetBitmap[3] = (sourceBitmap1[3] + sourceBitmap1[7] +
+                           sourceBitmap2[3] + sourceBitmap2[7]) /
+                          4;
 
         targetBitmap += 4;
         sourceBitmap1 += 8;
@@ -178,52 +179,49 @@ void SliSource::reduceRgb(int zoom, bool multithreading) {
 
   // create a new surface for this zoom level, unless it already exists
   SurfaceWrapper::Ptr targetSurface = SurfaceWrapper::create();
-  if (rgbCache.count(zoom))
-  {
+  if (rgbCache.count(zoom)) {
     targetSurface = rgbCache[zoom];
-  }
-  else
-  {
-    targetSurface = SurfaceWrapper::create(totalTargetWidth, totalTargetHeight, CAIRO_FORMAT_ARGB32);
+  } else {
+    targetSurface = SurfaceWrapper::create(totalTargetWidth, totalTargetHeight,
+                                           CAIRO_FORMAT_ARGB32);
   }
 
   unsigned int nSegments = 24; // just an arbitrary choice
   int baseSegHeight = findBestSegFit(nSegments, total_height);
   nSegments = (unsigned int)(total_height / baseSegHeight);
-  boost::dynamic_bitset<> toggledSegments {nSegments};
+  boost::dynamic_bitset<> toggledSegments{nSegments};
   auto spanRect = spannedRectangle(toggled, layers);
 
-  // find which segments intersect with the rectangle spanned by the toggled layers
+  // find which segments intersect with the rectangle spanned by the toggled
+  // layers
   int n = 0;
-  for (int i = 0; i < (int)nSegments; i++)
-  {
-    Scroom::Utils::Rectangle<int> seg = {0, baseSegHeight * i, total_width, baseSegHeight};
-    if (seg.intersects(spanRect))
-    {
+  for (int i = 0; i < (int)nSegments; i++) {
+    Scroom::Utils::Rectangle<int> seg = {0, baseSegHeight * i, total_width,
+                                         baseSegHeight};
+    if (seg.intersects(spanRect)) {
       toggledSegments.set(i);
       n++;
     }
   }
 
-  // since all segments are disjoint, we can assign one thread to cover half of them
-  if (multithreading && (n/(double)nSegments) >= 0.25)
-  {
+  // since all segments are disjoint, we can assign one thread to cover half of
+  // them
+  if (multithreading && (n / (double)nSegments) >= 0.25) {
     auto bitmask = halfSegBitmask(toggledSegments);
     auto toggledSegments1 = toggledSegments & bitmask;
     auto toggledSegments2 = toggledSegments & ~bitmask;
-    boost::thread thread(boost::bind(&SliSource::reduceSegments, shared_from_this<SliSource>(),
-                        targetSurface, toggledSegments2, baseSegHeight, zoom));
+    boost::thread thread(
+        boost::bind(&SliSource::reduceSegments, shared_from_this<SliSource>(),
+                    targetSurface, toggledSegments2, baseSegHeight, zoom));
 
     // reduce the segments and copy them over to the targetSurface
     reduceSegments(targetSurface, toggledSegments1, baseSegHeight, zoom);
 
     thread.join();
+  } else {
+    reduceSegments(targetSurface, toggledSegments, baseSegHeight, zoom);
   }
-  else
-  {
-    reduceSegments(targetSurface, toggledSegments, baseSegHeight, zoom); 
-  }
-  
+
   if (!rgbCache.count(zoom))
     rgbCache[zoom] = targetSurface;
 }

--- a/plugins/sep/sli/slisource.cc
+++ b/plugins/sep/sli/slisource.cc
@@ -81,16 +81,6 @@ void SliSource::queryImportBitmaps() {
 }
 
 void SliSource::wipeCache() {
-  // Erase all cache levels except for the bottom layer
-  auto it = rgbCache.begin();
-  while (it != rgbCache.end()) {
-    if (it->first != 0) {
-      it = rgbCache.erase(it);
-    } else {
-      it++;
-    }
-  }
-  // Clear the area of the last toggled layer from the bottom surface
   clearBottomSurface();
 }
 
@@ -99,83 +89,143 @@ SurfaceWrapper::Ptr SliSource::getSurface(int zoom) {
     return nullptr;
   } else if (!rgbCache.count(std::min(0, zoom)) || rgbCache[0]->clear) {
     CpuBound()->schedule(
-        boost::bind(&SliSource::fillCache, shared_from_this<SliSource>(), zoom),
+        boost::bind(&SliSource::fillCache, shared_from_this<SliSource>()),
         PRIO_HIGHER, threadQueue);
+    if (rgbCache.count(std::min(0, zoom))) {
+      return rgbCache[std::min(0, zoom)];
+    }
     return nullptr;
   } else {
     return rgbCache[std::min(0, zoom)];
   }
 }
-void SliSource::fillCache(int zoom) {
+void SliSource::fillCache() {
   mtx.lock();
   disableInteractions();
+  visible ^= toggled;
 
-  if (!rgbCache.count(0) || rgbCache[0]->clear) {
+  if (!rgbCache.count(0) || rgbCache[0]->clear)
+  {
     computeRgb();
-  }
-  if (zoom < 0) {
-    for (int i = -1; i >= zoom; i--) {
-      if (!rgbCache.count(i)) {
-        reduceRgb(i);
-      }
+
+    for (int i = -1; i >= -30; i--)
+    {
+      // true -> uses multithreading
+      reduceRgb(i, true);
     }
   }
+  
+  rgbCache[0]->clear = false;
+  toggled.reset();
   enableInteractions();
   mtx.unlock();
   triggerRedraw();
 }
 
-void SliSource::reduceRgb(int zoom) {
-  // printf("Computing for zoom %d\n", zoom);
+void SliSource::reduceSegments(SurfaceWrapper::Ptr targetSurface, boost::dynamic_bitset<> toggledSegments,
+                              int baseSegHeight, int zoom) {
+  for (int i = 0; i < (int)toggledSegments.size(); i++)
+  {
+    if (!toggledSegments[i])
+      continue;
 
-  const int sourceWidth = total_width / pow(2, -zoom - 1);
-  const int sourceHeight = total_height / pow(2, -zoom - 1);
-  const int sourceStride = rgbCache[zoom + 1]->getStride();
-  Scroom::Bitmap::SampleIterator<const uint8_t> sourceBase(
-      rgbCache[zoom + 1]->getBitmap(), 0, 8);
+    const int sourceWidth = total_width / pow(2, -zoom - 1);
+    const int sourceOffset = (baseSegHeight / pow(2, -zoom - 1)) * i;
+    const int sourceStride = rgbCache[zoom + 1]->getStride();
 
-  const int targetWidth = sourceWidth / 2;
-  const int targetHeight = sourceHeight / 2;
-  SurfaceWrapper::Ptr targetSurface =
-      SurfaceWrapper::create(targetWidth, targetHeight, CAIRO_FORMAT_ARGB32);
-  const int targetStride = targetSurface->getStride();
-  Scroom::Bitmap::SampleIterator<uint8_t> targetBase(targetSurface->getBitmap(),
-                                                     0, 8);
-
-  for (int y = 0; y < targetHeight; y++) {
-    auto targetSample = targetBase;
-
-    for (int x = 0; x < targetWidth; x++) {
-      // We want to store the average colour of the 2*2 pixel image
-      // with (x, y) as its top-left corner into targetSample.
-      auto sourceRow = sourceBase + 2 * 4 * x; // 2 pixels of 4 samples times x
-
-      int sum_a = 0;
-      int sum_r = 0;
-      int sum_g = 0;
-      int sum_b = 0;
-      for (size_t row = 0; row < 2; row++, sourceRow += sourceStride) {
-        auto sourceSample = sourceRow;
-        for (size_t current = 0; current < 2; current++) {
-          sum_a += *sourceSample++;
-          sum_r += *sourceSample++;
-          sum_g += *sourceSample++;
-          sum_b += *sourceSample++;
-        }
-      }
-
-      (targetSample++).set(sum_a / 4);
-      (targetSample++).set(sum_r / 4);
-      (targetSample++).set(sum_g / 4);
-      (targetSample++).set(sum_b / 4);
+    int targetSegHeight;
+    if (i == (int)toggledSegments.size() - 1)
+    {
+      // the last segment will probably have leftover pixels
+      int leftoverPixels = (total_height % baseSegHeight) / pow(2, -zoom);
+      targetSegHeight = (baseSegHeight / pow(2, -zoom)) + leftoverPixels;
+    }
+    else
+    {
+      targetSegHeight = baseSegHeight / pow(2, -zoom);
     }
 
-    targetBase += targetStride;     // Advance 1 row
-    sourceBase += sourceStride * 2; // Advance 2 rows
+    const int targetWidth = sourceWidth / 2;
+    const int targetOffset = (baseSegHeight / pow(2, -zoom)) * i;
+    auto targetStride = targetSurface->getStride();
+    auto targetBitmap = targetSurface->getBitmap() + targetOffset * targetStride;
+
+    for (int y = 0; y < targetSegHeight; y++)
+    {
+      auto sourceBitmap1 = rgbCache[zoom + 1]->getBitmap() + 2*y*sourceStride + sourceOffset*sourceStride;
+      auto sourceBitmap2 = sourceBitmap1 + sourceStride;
+
+      for (int x = 0; x < targetWidth; x++)
+      {
+        targetBitmap[0] = (sourceBitmap1[0] + sourceBitmap1[4] + sourceBitmap2[0] + sourceBitmap2[4]) / 4;
+        targetBitmap[1] = (sourceBitmap1[1] + sourceBitmap1[5] + sourceBitmap2[1] + sourceBitmap2[5]) / 4;
+        targetBitmap[2] = (sourceBitmap1[2] + sourceBitmap1[6] + sourceBitmap2[2] + sourceBitmap2[6]) / 4;
+        targetBitmap[3] = (sourceBitmap1[3] + sourceBitmap1[7] + sourceBitmap2[3] + sourceBitmap2[7]) / 4;
+
+        targetBitmap += 4;
+        sourceBitmap1 += 8;
+        sourceBitmap2 += 8;
+      }
+    }
+  }
+}
+
+void SliSource::reduceRgb(int zoom, bool multithreading) {
+  // the total width of the reduced image
+  const int totalTargetWidth = total_width / pow(2, -zoom);
+  // the total height of the reduced image
+  const int totalTargetHeight = total_height / pow(2, -zoom);
+
+  // create a new surface for this zoom level, unless it already exists
+  SurfaceWrapper::Ptr targetSurface = SurfaceWrapper::create();
+  if (rgbCache.count(zoom))
+  {
+    targetSurface = rgbCache[zoom];
+  }
+  else
+  {
+    targetSurface = SurfaceWrapper::create(totalTargetWidth, totalTargetHeight, CAIRO_FORMAT_ARGB32);
   }
 
-  // Make the cached bitmap available to the main thread
-  rgbCache[zoom] = targetSurface;
+  unsigned int nSegments = 24; // just an arbitrary choice
+  int baseSegHeight = findBestSegFit(nSegments, total_height);
+  nSegments = (unsigned int)(total_height / baseSegHeight);
+  boost::dynamic_bitset<> toggledSegments {nSegments};
+  auto spanRect = spannedRectangle(toggled, layers);
+
+  // find which segments intersect with the rectangle spanned by the toggled layers
+  int n = 0;
+  for (int i = 0; i < (int)nSegments; i++)
+  {
+    Scroom::Utils::Rectangle<int> seg = {0, baseSegHeight * i, total_width, baseSegHeight};
+    if (seg.intersects(spanRect))
+    {
+      toggledSegments.set(i);
+      n++;
+    }
+  }
+
+  // since all segments are disjoint, we can assign one thread to cover half of them
+  if (multithreading && (n/(double)nSegments) >= 0.25)
+  {
+    auto bitmask = halfSegBitmask(toggledSegments);
+    auto toggledSegments1 = toggledSegments & bitmask;
+    auto toggledSegments2 = toggledSegments & ~bitmask;
+    boost::thread thread(boost::bind(&SliSource::reduceSegments, shared_from_this<SliSource>(),
+                        targetSurface, toggledSegments2, baseSegHeight, zoom));
+
+    // reduce the segments and copy them over to the targetSurface
+    reduceSegments(targetSurface, toggledSegments1, baseSegHeight, zoom);
+
+    thread.join();
+  }
+  else
+  {
+    reduceSegments(targetSurface, toggledSegments, baseSegHeight, zoom); 
+  }
+  
+  if (!rgbCache.count(zoom))
+    rgbCache[zoom] = targetSurface;
 }
 
 void SliSource::convertCmykXoffset(uint8_t *surfacePointer,
@@ -264,9 +314,6 @@ void SliSource::drawCmykXoffset(uint8_t *surfacePointer, uint8_t *bitmap,
 }
 
 void SliSource::computeRgb() {
-  // Update the visibility of all layers according to the toggled ones
-  visible ^= toggled;
-
   SurfaceWrapper::Ptr surface = SurfaceWrapper::create();
 
   // Check if cache surface exists first
@@ -335,10 +382,9 @@ void SliSource::computeRgb() {
   }
 
   cairo_surface_mark_dirty(surface->surface);
-  toggled.reset();
+
   if (!rgbCache.count(0))
     rgbCache[0] = surface;
-  rgbCache[0]->clear = false;
 }
 
 void SliSource::clearBottomSurface() {

--- a/plugins/sep/sli/slisource.hh
+++ b/plugins/sep/sli/slisource.hh
@@ -76,18 +76,29 @@ private:
 
   /**
    * Reduces the RGB bitmap and caches the result.
-   * 2x2 pixels of the @param zoom+1 bitmap are combined into one pixel of the
-   * zoom bitmap
+   * The bitmap is divided into roughly 24+ segments whose height is a multiple of 2.
+   * This creates a one-to-one mapping bewteen each pixel of zoom level @param zoom
+   * and a 2x2 square of pixels of zoom level @param zoom+1.
+   * @param multithreading indicates whether more than one thread will "possibly" be used for the reduction.
+   * This choice also depends on the number of toggled segments: if only a handful are toggled,
+   * the additional overhead of threads is not worth it.
    */
-  virtual void reduceRgb(int zoom);
+  virtual void reduceRgb(int zoom, bool multithreading);
+
+  /**
+   * Reduces all the segments set in @param toggledSegments for zoom level @param zoom.
+   * @param baseSegHeight is the height of a segment in the base surface (zoom level 0).
+   * @param targetSurface is the surface on top of which the reduced segments will be copied.
+   */
+  virtual void reduceSegments(SurfaceWrapper::Ptr targetSurface, boost::dynamic_bitset<> toggledSegments,
+                            int baseSegHeight, int zoom);
 
   /**
    * Checks if the bitmap required for displaying the zoom level is present. If
    * not, it is computed. Is potentially very computationally expensive, hence
    * run outside of the UI thread.
-   * @param zoom the zoom level for which to fill the cache
    */
-  virtual void fillCache(int zoom);
+  virtual void fillCache();
 
   /** Clear the last modified area of the bottom surface */
   virtual void clearBottomSurface();

--- a/plugins/sep/sli/slisource.hh
+++ b/plugins/sep/sli/slisource.hh
@@ -76,22 +76,27 @@ private:
 
   /**
    * Reduces the RGB bitmap and caches the result.
-   * The bitmap is divided into roughly 24+ segments whose height is a multiple of 2.
-   * This creates a one-to-one mapping bewteen each pixel of zoom level @param zoom
-   * and a 2x2 square of pixels of zoom level @param zoom+1.
-   * @param multithreading indicates whether more than one thread will "possibly" be used for the reduction.
-   * This choice also depends on the number of toggled segments: if only a handful are toggled,
-   * the additional overhead of threads is not worth it.
+   * The bitmap is divided into roughly 24+ segments whose height is a multiple
+   * of 2. This creates a one-to-one mapping bewteen each pixel of zoom level
+   * @param zoom and a 2x2 square of pixels of zoom level @param zoom+1.
+   * @param multithreading indicates whether more than one thread will
+   * "possibly" be used for the reduction. This choice also depends on the
+   * number of toggled segments: if only a handful are toggled, the additional
+   * overhead of threads is not worth it.
    */
   virtual void reduceRgb(int zoom, bool multithreading);
 
   /**
-   * Reduces all the segments set in @param toggledSegments for zoom level @param zoom.
-   * @param baseSegHeight is the height of a segment in the base surface (zoom level 0).
-   * @param targetSurface is the surface on top of which the reduced segments will be copied.
+   * Reduces all the segments set in @param toggledSegments for zoom level
+   * @param zoom.
+   * @param baseSegHeight is the height of a segment in the base surface (zoom
+   * level 0).
+   * @param targetSurface is the surface on top of which the reduced segments
+   * will be copied.
    */
-  virtual void reduceSegments(SurfaceWrapper::Ptr targetSurface, boost::dynamic_bitset<> toggledSegments,
-                            int baseSegHeight, int zoom);
+  virtual void reduceSegments(SurfaceWrapper::Ptr targetSurface,
+                              boost::dynamic_bitset<> toggledSegments,
+                              int baseSegHeight, int zoom);
 
   /**
    * Checks if the bitmap required for displaying the zoom level is present. If

--- a/plugins/sep/sli/slisource.hh
+++ b/plugins/sep/sli/slisource.hh
@@ -77,7 +77,7 @@ private:
   /**
    * Reduces the RGB bitmap and caches the result.
    * The bitmap is divided into roughly 24+ segments whose height is a multiple
-   * of 2. This creates a one-to-one mapping bewteen each pixel of zoom level
+   * of 2. This creates a one-to-one mapping between each pixel of zoom level
    * @param zoom and a 2x2 square of pixels of zoom level @param zoom+1.
    * @param multithreading indicates whether more than one thread will
    * "possibly" be used for the reduction. This choice also depends on the
@@ -226,8 +226,8 @@ public:
   virtual void queryImportBitmaps();
 
   /**
-   *  Erase the RGB cache of the SliSource except for the bottom layer
-   *  for which the relevant bytes are simply turned to 0s.
+   * Clear (ie write 0s) the area of the bottom surface intersecting with the
+   * toggled layers and trigger a redraw.
    */
-  virtual void wipeCache();
+  virtual void wipeCacheAndRedraw();
 };


### PR DESCRIPTION
This PR will make drawing and toggling SLI layers a lot faster. Moreover, as Peter requested, after the initial image has been loaded, every time layers are toggled, the previous image will be shown instead of the green background while processing. This should be less distracting. The sidebar UI will still be grayed-out in the meantime to indicate that something is being processed.