### PR TITLE
Small bugfixes to varnish+sep

### DIFF
--- a/plugins/sep/sepsource.cc
+++ b/plugins/sep/sepsource.cc
@@ -235,6 +235,7 @@ void SepSource::openFiles() {
     SliLayer::Ptr varnishLayer =
         SliLayer::create(sep_file.files["V"].string(), "Varnish", 0, 0);
     if (varnishLayer->fillMetaFromTiff(8, 1)) {
+      varnishLayer->fillBitmapFromTiff();
       varnish = Varnish::create(varnishLayer);
     } else {
       show_warning = true;

--- a/plugins/sep/test/varnish-tests.cc
+++ b/plugins/sep/test/varnish-tests.cc
@@ -59,7 +59,6 @@ BOOST_AUTO_TEST_CASE(varnish_load_ui) {
   test_varnishLayer->fillBitmapFromTiff();
   Varnish::Ptr test_varnish = Varnish::create(test_varnishLayer);
   test_varnish->setView(dvi);
-  test_varnish->forceRedraw();
   test_varnish->invertSurface();
 
   // Inverting twice should return the same thing.

--- a/plugins/sep/test/varnish-tests.cc
+++ b/plugins/sep/test/varnish-tests.cc
@@ -47,6 +47,8 @@ public:
   void addToolButton(GtkToggleButton *, ToolStateListener::Ptr){};
 };
 
+void dummyFunction() {};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Tests for varnish ui construction
 
@@ -58,6 +60,7 @@ BOOST_AUTO_TEST_CASE(varnish_load_ui) {
   test_varnishLayer->fillMetaFromTiff(8, 1);
   test_varnishLayer->fillBitmapFromTiff();
   Varnish::Ptr test_varnish = Varnish::create(test_varnishLayer);
+  test_varnish->triggerRedraw = boost::bind(dummyFunction);
   test_varnish->setView(dvi);
   test_varnish->invertSurface();
 


### PR DESCRIPTION
Two small diffs to fix issues that arose from a refactor:
1.  The varnish mask was not being filled.
1.  A test file still contained a reference to an older redraw function that no longer exists
