### PR TITLE
Fix compilation issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ plugins_sep_src_libspsep_la_SOURCES = \
 	plugins/sep/varnish/varnish.cc \
 	plugins/sep/varnish/varnish.hh
 
-plugins_sep_src_libspsep_la_LIBADD = @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff -ldl -lpthread
+plugins_sep_src_libspsep_la_LIBADD = @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff -lpthread
 
 plugins_sep_src_libspsep_la_LDFLAGS = $(loadflag) -I../scroom/gui/src/ -pthread
 


### PR DESCRIPTION
- Eliminate dependency on libdl, which isn't needed, and the Windows build cannot find it any more
- Switch to the latest Scroom version, with (amongst many cleanups) an updated script for gathering dependent libraries on windows