### PR TITLE
Update tests to work under CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,4 @@ plugin-build/*
 plugins/sep/test/sep-tests
 gmon.out
 plugins/pipette/test/pipette-tests
-.idea
-cmake-build-debug
+/cmake-build-*

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ plugin-build/*
 plugins/sep/test/sep-tests
 gmon.out
 plugins/pipette/test/pipette-tests
+.idea
+cmake-build-debug

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ScroomCPPPlugins

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/scroom-plugin-cpp.iml" filepath="$PROJECT_DIR$/.idea/scroom-plugin-cpp.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/scroom-plugin-cpp.iml
+++ b/.idea/scroom-plugin-cpp.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/scroom" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/scroom/cmake-modules" vcs="Git" />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 project(ScroomCPPPlugins LANGUAGES CXX)
 
 add_subdirectory(scroom)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.15)
 project(ScroomCPPPlugins LANGUAGES CXX)
 
+option(ENABLE_BOOST_TEST "Enable Boost Test builds" ON)
+
+# Collect all libraries and binaries in a single location
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+
 add_subdirectory(scroom)
 add_subdirectory(plugins)
+
+# Generate the ENVIRONMENT file
+set(abs_top_builddir "${ScroomCPPPlugins_BINARY_DIR}")
+configure_file(ENVIRONMENT.in ${ScroomCPPPlugins_BINARY_DIR}/ENVIRONMENT @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+project(ScroomCPPPlugins LANGUAGES CXX)
+
+add_subdirectory(scroom)
+add_subdirectory(plugins)

--- a/ENVIRONMENT.in
+++ b/ENVIRONMENT.in
@@ -1,0 +1,3 @@
+ATB=@abs_top_builddir@
+export SCROOM_DEV_MODE="yes"
+export SCROOM_PLUGIN_DIRS="${ATB}/scroom/lib:${ATB}/lib"

--- a/ENVIRONMENT.in
+++ b/ENVIRONMENT.in
@@ -1,4 +1,3 @@
 ATB=@abs_top_builddir@
 export SCROOM_DEV_MODE="yes"
-export SCROOM_PLUGIN_DIRS="/some/bogus/value:${ATB}/lib:${ATB}/scroom/plugins/colormap/.libs:${ATB}/scroom/plugins/tiff/src/.libs:${ATB}/scroom/plugins/example/.libs:${ATB}/scroom/plugins/transparent-overlay/src/.libs:${ATB}/scroom/plugins/measure/src/.libs:${ATB}/scroom/plugins/pipette/src/.libs:${ATB}/scroom/lib"
-
+export SCROOM_PLUGIN_DIRS="${ATB}/scroom/lib:${ATB}/lib"

--- a/ENVIRONMENT.in
+++ b/ENVIRONMENT.in
@@ -1,3 +1,4 @@
 ATB=@abs_top_builddir@
 export SCROOM_DEV_MODE="yes"
-export SCROOM_PLUGIN_DIRS="${ATB}/scroom/lib:${ATB}/lib"
+export SCROOM_PLUGIN_DIRS="/some/bogus/value:${ATB}/lib:${ATB}/scroom/plugins/colormap/.libs:${ATB}/scroom/plugins/tiff/src/.libs:${ATB}/scroom/plugins/example/.libs:${ATB}/scroom/plugins/transparent-overlay/src/.libs:${ATB}/scroom/plugins/measure/src/.libs:${ATB}/scroom/plugins/pipette/src/.libs:${ATB}/scroom/lib"
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,9 @@ plugins_sep_test_sep_tests_SOURCES = \
 	plugins/sep/test/sephelpers-tests.cc \
 	plugins/sep/test/varnish-tests.cc \
 	plugins/sep/test/seppresentation-tests.cc \
-	plugins/sep/test/sep-tests.cc
+	plugins/sep/test/sep-tests.cc \
+	plugins/sep/test/constants.cc \
+	plugins/sep/test/constants.hh
 
 plugins_sep_test_sep_tests_LDADD = \
 	@BOOSTTESTLIB@ @SEPPLUGIN_LIBS@ @BOOSTTHREADLIB@ @TILEDBITMAPLIB@ @SCROOMLIB@ @BOOSTFILESYSTEMLIB@ @THREADPOOLLIB@ -ltiff -ldl -lpthread \

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(sep)

--- a/plugins/sep/CMakeLists.txt
+++ b/plugins/sep/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ENABLE_BOOST_TEST)
           test/varnish-tests.cc
           test/constants.cc
           test/constants.hh)
-  #target_include_directories(spsep_tests PRIVATE sli)
+  target_include_directories(spsep_tests PRIVATE sli)
   target_link_libraries(
     spsep_tests
     PRIVATE boosttesthelper
@@ -62,8 +62,6 @@ if(ENABLE_BOOST_TEST)
             spsep
             tiledbitmap
             util)
-
-  file(COPY test/testfiles DESTINATION ${CMAKE_BINARY_DIR})
 
   add_test(NAME spsep_tests COMMAND spsep_tests)
 endif()

--- a/plugins/sep/CMakeLists.txt
+++ b/plugins/sep/CMakeLists.txt
@@ -49,7 +49,9 @@ if(ENABLE_BOOST_TEST)
           test/slihelpers-tests.cc
           test/slipresentation-tests.cc
           test/slisource-tests.cc
-          test/varnish-tests.cc)
+          test/varnish-tests.cc
+          test/constants.cc
+          test/constants.hh)
   #target_include_directories(spsep_tests PRIVATE sli)
   target_link_libraries(
     spsep_tests

--- a/plugins/sep/CMakeLists.txt
+++ b/plugins/sep/CMakeLists.txt
@@ -1,0 +1,65 @@
+add_library(spsep SHARED)
+target_sources(spsep
+        PRIVATE
+        main.cc
+        sep.cc
+        sep.hh
+        sep-helpers.cc
+        sep-helpers.hh
+        seppresentation.cc
+        seppresentation.hh
+        sepsource.cc
+        sepsource.hh
+        sli/sli-helpers.cc
+        sli/sli-helpers.hh
+        sli/slicontrolpanel.cc
+        sli/slicontrolpanel.hh
+        sli/slilayer.cc
+        sli/slilayer.hh
+        sli/slipresentation.cc
+        sli/slipresentation.hh
+        sli/slipresentationinterface.hh
+        sli/slisource.cc
+        sli/slisource.hh
+        varnish/varnish.cc
+        varnish/varnish.hh)
+target_link_libraries(
+  spsep
+        PRIVATE project_options project_warnings
+        PUBLIC PkgConfig::gtk threadpool PkgConfig::cairo
+        boost_filesystem
+        scroom_lib
+        TIFF::TIFF
+        m
+        util
+        dl)
+
+install(TARGETS spsep DESTINATION ${PLUGIN_INSTALL_LOCATION_RELATIVE})
+install_plugin_dependencies(spsep)
+
+if(ENABLE_BOOST_TEST)
+  add_executable(spsep_tests)
+  target_sources(spsep_tests
+          PRIVATE
+          test/main.cc
+          test/sep-tests.cc
+          test/sephelpers-tests.cc
+          test/seppresentation-tests.cc
+          test/sepsource-tests.cc
+          test/slihelpers-tests.cc
+          test/slipresentation-tests.cc
+          test/slisource-tests.cc
+          test/varnish-tests.cc)
+  target_include_directories(spsep_tests PRIVATE sli)
+  target_link_libraries(
+    spsep_tests
+    PRIVATE boosttesthelper
+            #Boost::chrono
+            project_options
+            project_warnings
+            spsep
+            tiledbitmap
+            util)
+
+  add_test(NAME spsep_tests COMMAND spsep_tests)
+endif()

--- a/plugins/sep/CMakeLists.txt
+++ b/plugins/sep/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(
 install(TARGETS spsep DESTINATION ${PLUGIN_INSTALL_LOCATION_RELATIVE})
 install_plugin_dependencies(spsep)
 
+message("spsep: " ${PLUGIN_INSTALL_LOCATION_RELATIVE})
+
 if(ENABLE_BOOST_TEST)
   add_executable(spsep_tests)
   target_sources(spsep_tests
@@ -60,6 +62,44 @@ if(ENABLE_BOOST_TEST)
             spsep
             tiledbitmap
             util)
+
+  # We explicitly create a directory for the files beforehand
+  # so we can just specify the directory in the configure_file command
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/testfiles)
+  # Copy test files to build directory
+  configure_file(test/testfiles/C.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/K.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/M.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/M_9.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_cmyk.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_cmykv.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_empty_line_2.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_empty_line_3.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_extra_lines.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_missing_channel.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sep_test.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_pipette.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_scale.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_seponly.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_septiffmixed.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_tiffonly.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_tinycmyk.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_tinycmyk_xoffset.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_varnish.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_varnish_wrongpath.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/sli_xoffset.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/tiff_cmyk.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/tinycmyk.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_corrupted.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_invalid1bps.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_invalid_no_bps_tag.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_invalid_no_width.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_invalid_zero_res.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_invalidrgb.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_valid.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_valid_centimeter.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/v_valid_no_spp_tag.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  configure_file(test/testfiles/Y.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
 
   add_test(NAME spsep_tests COMMAND spsep_tests)
 endif()

--- a/plugins/sep/CMakeLists.txt
+++ b/plugins/sep/CMakeLists.txt
@@ -50,7 +50,7 @@ if(ENABLE_BOOST_TEST)
           test/slipresentation-tests.cc
           test/slisource-tests.cc
           test/varnish-tests.cc)
-  target_include_directories(spsep_tests PRIVATE sli)
+  #target_include_directories(spsep_tests PRIVATE sli)
   target_link_libraries(
     spsep_tests
     PRIVATE boosttesthelper

--- a/plugins/sep/CMakeLists.txt
+++ b/plugins/sep/CMakeLists.txt
@@ -37,8 +37,6 @@ target_link_libraries(
 install(TARGETS spsep DESTINATION ${PLUGIN_INSTALL_LOCATION_RELATIVE})
 install_plugin_dependencies(spsep)
 
-message("spsep: " ${PLUGIN_INSTALL_LOCATION_RELATIVE})
-
 if(ENABLE_BOOST_TEST)
   add_executable(spsep_tests)
   target_sources(spsep_tests
@@ -63,43 +61,7 @@ if(ENABLE_BOOST_TEST)
             tiledbitmap
             util)
 
-  # We explicitly create a directory for the files beforehand
-  # so we can just specify the directory in the configure_file command
-  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/testfiles)
-  # Copy test files to build directory
-  configure_file(test/testfiles/C.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/K.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/M.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/M_9.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_cmyk.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_cmykv.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_empty_line_2.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_empty_line_3.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_extra_lines.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_missing_channel.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sep_test.sep ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_pipette.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_scale.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_seponly.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_septiffmixed.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_tiffonly.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_tinycmyk.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_tinycmyk_xoffset.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_varnish.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_varnish_wrongpath.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/sli_xoffset.sli ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/tiff_cmyk.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/tinycmyk.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_corrupted.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_invalid1bps.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_invalid_no_bps_tag.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_invalid_no_width.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_invalid_zero_res.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_invalidrgb.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_valid.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_valid_centimeter.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/v_valid_no_spp_tag.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
-  configure_file(test/testfiles/Y.tif ${CMAKE_BINARY_DIR}/testfiles COPYONLY)
+  file(COPY test/testfiles DESTINATION ${CMAKE_BINARY_DIR})
 
   add_test(NAME spsep_tests COMMAND spsep_tests)
 endif()

--- a/plugins/sep/test/constants.cc
+++ b/plugins/sep/test/constants.cc
@@ -2,5 +2,5 @@
 
 #include <boost/dll.hpp>
 
-extern const boost::filesystem::path testFileDir = boost::dll::program_location().parent_path().parent_path() / "testfiles";
+extern boost::filesystem::path testFileDir = boost::dll::program_location().parent_path().parent_path() / "testfiles";
 

--- a/plugins/sep/test/constants.cc
+++ b/plugins/sep/test/constants.cc
@@ -1,0 +1,6 @@
+#include "constants.hh"
+
+#include <boost/dll.hpp>
+
+extern const boost::filesystem::path testFileDir = boost::dll::program_location().parent_path().parent_path() / "testfiles";
+

--- a/plugins/sep/test/constants.hh
+++ b/plugins/sep/test/constants.hh
@@ -7,6 +7,6 @@
 
 #include <boost/dll.hpp>
 
-extern const boost::filesystem::path testFileDir;
+extern boost::filesystem::path testFileDir;
 
 #endif //SCROOMCPPPLUGINS_TEST_CONSTANTS_HH

--- a/plugins/sep/test/constants.hh
+++ b/plugins/sep/test/constants.hh
@@ -1,0 +1,12 @@
+//
+// Created by developer on 17-05-21.
+//
+
+#ifndef SCROOMCPPPLUGINS_TEST_CONSTANTS_HH
+#define SCROOMCPPPLUGINS_TEST_CONSTANTS_HH
+
+#include <boost/dll.hpp>
+
+extern const boost::filesystem::path testFileDir;
+
+#endif //SCROOMCPPPLUGINS_TEST_CONSTANTS_HH

--- a/plugins/sep/test/main.cc
+++ b/plugins/sep/test/main.cc
@@ -1,3 +1,27 @@
 #define BOOST_TEST_MODULE Sep tests
 #define BOOST_TEST_DYN_LINK
+#include <boost/dll.hpp>
 #include <boost/test/unit_test.hpp>
+#include "constants.hh"
+
+// We use this struct as a global fixture to initialize the global
+// variable testFileDir based on a command line argument containing the path
+// to the directory containing the test files
+namespace utf = boost::unit_test;
+struct F {
+    F() {
+        BOOST_TEST_MESSAGE("setup fixture");
+        if (utf::framework::master_test_suite().argc < 2){
+            // Use a default location if no arguments were passed
+            testFileDir = (boost::dll::program_location().parent_path().parent_path() / "testfiles").string();
+        } else {
+            testFileDir = utf::framework::master_test_suite().argv[1];
+        }
+        BOOST_TEST_MESSAGE("Using the test files located in " + testFileDir.string());
+    }
+    ~F() {
+        BOOST_TEST_MESSAGE("teardown fixture");
+    }
+};
+// Register the fixture with the test module
+BOOST_GLOBAL_FIXTURE(F);

--- a/plugins/sep/test/seppresentation-tests.cc
+++ b/plugins/sep/test/seppresentation-tests.cc
@@ -7,8 +7,7 @@
 
 #include "../seppresentation.hh"
 
-const auto testFileDir =
-    boost::dll::program_location().parent_path().parent_path() / "testfiles";
+#include "constants.hh"
 
 /** Test cases for seppresentation.hh */
 

--- a/plugins/sep/test/sepsource-tests.cc
+++ b/plugins/sep/test/sepsource-tests.cc
@@ -6,9 +6,7 @@
 
 #include "../sepsource.hh"
 #include "../sli/slilayer.hh"
-
-const auto testFileDir =
-    boost::dll::program_location().parent_path().parent_path() / "testfiles";
+#include "constants.hh"
 
 /** Test cases for sepsource.hh */
 

--- a/plugins/sep/test/slipresentation-tests.cc
+++ b/plugins/sep/test/slipresentation-tests.cc
@@ -10,9 +10,7 @@
 
 #define SLI_NOF_LAYERS 4
 
-const std::string testFileDir =
-    boost::dll::program_location().parent_path().parent_path().string() +
-    "/testfiles/";
+#include "constants.hh"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Helper functions
@@ -55,56 +53,56 @@ BOOST_AUTO_TEST_SUITE(Sli_Tests)
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_tiffonly) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_tiffonly.sli");
+  presentation->load((testFileDir / "sli_tiffonly.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == SLI_NOF_LAYERS);
   dummyRedraw(presentation);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_seponly) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_seponly.sli");
+  presentation->load((testFileDir / "sli_seponly.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == SLI_NOF_LAYERS);
   dummyRedraw(presentation);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_septiffmixed) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_septiffmixed.sli");
+  presentation->load((testFileDir / "sli_septiffmixed.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == SLI_NOF_LAYERS);
   dummyRedraw(presentation);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_scale) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_scale.sli");
+  presentation->load((testFileDir / "sli_scale.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == SLI_NOF_LAYERS);
   dummyRedraw(presentation);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_xoffset) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_xoffset.sli");
+  presentation->load((testFileDir / "sli_xoffset.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == SLI_NOF_LAYERS);
   dummyRedraw(presentation);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_varnish) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_varnish.sli");
+  presentation->load((testFileDir / "sli_varnish.sli").string());
   std::cout << presentation->getLayers().size() << '\n';
   BOOST_REQUIRE(presentation->getLayers().size() == SLI_NOF_LAYERS);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_load_sli_varnish_wrongpath) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_varnish_wrongpath.sli");
+  presentation->load((testFileDir / "sli_varnish_wrongpath.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_presentationinterface_inherited) {
-  std::string testFilePath = testFileDir + "sli_xoffset.sli";
+  std::string testFilePath = (testFileDir / "sli_xoffset.sli").string();
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir);
+  presentation->load(testFileDir.string());
 
   std::string nameStr = "testname";
   std::string valueStr;
@@ -119,7 +117,7 @@ BOOST_AUTO_TEST_CASE(slipresentation_presentationinterface_inherited) {
   BOOST_REQUIRE(presentation->getProperty(nameStr, valueStr) == true);
   BOOST_REQUIRE(valueStr == "testvalue");
 
-  BOOST_REQUIRE(presentation->getTitle() == testFileDir);
+  BOOST_REQUIRE(presentation->getTitle() == testFileDir.string());
 
   presentation.reset();
 }
@@ -127,7 +125,7 @@ BOOST_AUTO_TEST_CASE(slipresentation_presentationinterface_inherited) {
 BOOST_AUTO_TEST_CASE(slipresentation_pipette_tool_multiple_colors) {
   SliPresentation::Ptr presentation = createPresentation();
 
-  presentation->load(testFileDir + "sli_pipette.sli");
+  presentation->load((testFileDir / "sli_pipette.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == 1);
   dummyRedraw(presentation);
   // Testing 4 CMYK pixels + rectangle larger than the canvas
@@ -140,7 +138,7 @@ BOOST_AUTO_TEST_CASE(slipresentation_pipette_tool_multiple_colors) {
 BOOST_AUTO_TEST_CASE(slipresentation_pipette_tool_one_color) {
   SliPresentation::Ptr presentation = createPresentation();
 
-  presentation->load(testFileDir + "sli_pipette.sli");
+  presentation->load((testFileDir / "sli_pipette.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == 1);
   dummyRedraw(presentation);
   // C
@@ -163,7 +161,7 @@ BOOST_AUTO_TEST_CASE(slipresentation_pipette_tool_one_color) {
 
 BOOST_AUTO_TEST_CASE(slipresentation_pipette_tool_zero_area) {
   SliPresentation::Ptr presentation = createPresentation();
-  presentation->load(testFileDir + "sli_pipette.sli");
+  presentation->load((testFileDir / "sli_pipette.sli").string());
   BOOST_REQUIRE(presentation->getLayers().size() == 1);
   dummyRedraw(presentation);
 

--- a/plugins/sep/test/slipresentation-tests.cc
+++ b/plugins/sep/test/slipresentation-tests.cc
@@ -100,7 +100,6 @@ BOOST_AUTO_TEST_CASE(slipresentation_load_sli_varnish_wrongpath) {
 }
 
 BOOST_AUTO_TEST_CASE(slipresentation_presentationinterface_inherited) {
-  std::string testFilePath = (testFileDir / "sli_xoffset.sli").string();
   SliPresentation::Ptr presentation = createPresentation();
   presentation->load(testFileDir.string());
 

--- a/plugins/sep/test/slisource-tests.cc
+++ b/plugins/sep/test/slisource-tests.cc
@@ -10,9 +10,7 @@
 
 #define SLI_NOF_LAYERS 4
 
-const std::string testFileDir =
-    boost::dll::program_location().parent_path().parent_path().string() +
-    "/testfiles/";
+#include "constants.hh"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Helper functions
@@ -56,7 +54,7 @@ BOOST_AUTO_TEST_SUITE(Sli_Tests)
 BOOST_AUTO_TEST_CASE(slisource_clearbottomsurface_all_toggled) {
   SliPresentation::Ptr presentation = createPresentation1();
 
-  presentation->load(testFileDir + "sli_tiffonly.sli");
+  presentation->load((testFileDir / "sli_tiffonly.sli").string());
   dummyRedraw1(presentation);
   presentation->source->toggled = boost::dynamic_bitset<>{SLI_NOF_LAYERS}.set();
   presentation->source->clearBottomSurface();
@@ -77,8 +75,8 @@ BOOST_AUTO_TEST_CASE(slisource_clearbottomsurface_none_toggled) {
   SliPresentation::Ptr presentation1 = createPresentation1();
   SliPresentation::Ptr presentation2 = createPresentation1();
 
-  presentation1->load(testFileDir + "sli_tiffonly.sli");
-  presentation2->load(testFileDir + "sli_tiffonly.sli");
+  presentation1->load((testFileDir / "sli_tiffonly.sli").string());
+  presentation2->load((testFileDir / "sli_tiffonly.sli").string());
   dummyRedraw1(presentation1);
   dummyRedraw1(presentation2);
   presentation1->source->toggled = boost::dynamic_bitset<>{SLI_NOF_LAYERS};
@@ -101,8 +99,8 @@ BOOST_AUTO_TEST_CASE(slisource_clearbottomsurface_some_toggled) {
   SliPresentation::Ptr presentation1 = createPresentation1();
   SliPresentation::Ptr presentation2 = createPresentation1();
 
-  presentation1->load(testFileDir + "sli_tiffonly.sli");
-  presentation2->load(testFileDir + "sli_tiffonly.sli");
+  presentation1->load((testFileDir / "sli_tiffonly.sli").string());
+  presentation2->load((testFileDir / "sli_tiffonly.sli").string());
   dummyRedraw1(presentation1);
   dummyRedraw1(presentation2);
   presentation1->source->toggled =
@@ -139,7 +137,7 @@ BOOST_AUTO_TEST_CASE(slisource_clearbottomsurface_some_toggled) {
 //              [(255,255,0,255),(255,0,255,255),(0,255,255,255),(0,0,0,255)]
 BOOST_AUTO_TEST_CASE(slisource_computergb_yoffset) {
   SliPresentation::Ptr presentation = createPresentation1();
-  presentation->load(testFileDir + "sli_tinycmyk.sli");
+  presentation->load((testFileDir / "sli_tinycmyk.sli").string());
   dummyRedraw1(presentation);
   auto surface = presentation->source->getSurface(0)->getBitmap();
   presentation->source->computeRgb();
@@ -154,7 +152,7 @@ BOOST_AUTO_TEST_CASE(slisource_computergb_yoffset) {
 
 BOOST_AUTO_TEST_CASE(slisource_computergb_xoffset) {
   SliPresentation::Ptr presentation = createPresentation1();
-  presentation->load(testFileDir + "sli_tinycmyk_xoffset.sli");
+  presentation->load((testFileDir / "sli_tinycmyk_xoffset.sli").string());
   dummyRedraw1(presentation);
   auto surface = presentation->source->rgbCache[0]->getBitmap();
   presentation->source->computeRgb();

--- a/plugins/sep/test/varnish-tests.cc
+++ b/plugins/sep/test/varnish-tests.cc
@@ -8,10 +8,7 @@
 #include "../varnish/varnish.hh"
 #include <scroom/scroominterface.hh>
 #include <scroom/viewinterface.hh>
-
-const std::string testFileDir =
-    boost::dll::program_location().parent_path().parent_path().string() +
-    "/testfiles/";
+#include "constants.hh"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Helper object
@@ -56,7 +53,7 @@ BOOST_AUTO_TEST_SUITE(varnish_ui_tests)
 BOOST_AUTO_TEST_CASE(varnish_load_ui) {
   ViewInterface::Ptr dvi = DummyViewInterface::create();
   SliLayer::Ptr test_varnishLayer =
-      SliLayer::create(testFileDir + "v_valid.tif", "SomeCoolTitle", 0, 0);
+      SliLayer::create((testFileDir / "v_valid.tif").string(), "SomeCoolTitle", 0, 0);
   test_varnishLayer->fillMetaFromTiff(8, 1);
   test_varnishLayer->fillBitmapFromTiff();
   Varnish::Ptr test_varnish = Varnish::create(test_varnishLayer);
@@ -149,13 +146,13 @@ BOOST_AUTO_TEST_SUITE(varnish_tests)
 
 BOOST_AUTO_TEST_CASE(varnish_load_valid_tiff) {
   SliLayer::Ptr test_varnishLayer =
-      SliLayer::create(testFileDir + "v_valid.tif", "SomeCoolTitle", 0, 0);
+      SliLayer::create((testFileDir / "v_valid.tif").string(), "SomeCoolTitle", 0, 0);
   test_varnishLayer->fillMetaFromTiff(8, 1);
   test_varnishLayer->fillBitmapFromTiff();
   Varnish::Ptr test_varnish = Varnish::create(test_varnishLayer);
   // Properties set correctly?
   BOOST_REQUIRE(test_varnish->layer->name == "SomeCoolTitle");
-  BOOST_REQUIRE(test_varnish->layer->filepath == testFileDir + "v_valid.tif");
+  BOOST_REQUIRE(test_varnish->layer->filepath == (testFileDir / "v_valid.tif").string());
   BOOST_REQUIRE(test_varnish->layer->width == 20);
   BOOST_REQUIRE(test_varnish->layer->height == 20);
   BOOST_REQUIRE(test_varnish->layer->xoffset == 0);
@@ -169,14 +166,14 @@ BOOST_AUTO_TEST_CASE(varnish_load_valid_tiff) {
 
 BOOST_AUTO_TEST_CASE(varnish_load_valid_tiff_centimeter) {
   SliLayer::Ptr test_varnishLayer = SliLayer::create(
-      testFileDir + "v_valid_centimeter.tif", "SomeCoolTitle", 0, 0);
+      (testFileDir / "v_valid_centimeter.tif").string(), "SomeCoolTitle", 0, 0);
   test_varnishLayer->fillMetaFromTiff(8, 1);
   test_varnishLayer->fillBitmapFromTiff();
   Varnish::Ptr test_varnish = Varnish::create(test_varnishLayer);
   // Properties set correctly?
   BOOST_REQUIRE(test_varnish->layer->name == "SomeCoolTitle");
   BOOST_REQUIRE(test_varnish->layer->filepath ==
-                testFileDir + "v_valid_centimeter.tif");
+                (testFileDir / "v_valid_centimeter.tif").string());
   BOOST_REQUIRE(test_varnish->layer->width == 20);
   BOOST_REQUIRE(test_varnish->layer->height == 20);
   BOOST_REQUIRE(test_varnish->layer->xoffset == 0);
@@ -192,14 +189,14 @@ BOOST_AUTO_TEST_CASE(varnish_load_valid_tiff_no_spp_tag) {
   // This test file does not have a SamplePerPixel tag set, but should default
   // to 1 spp
   SliLayer::Ptr test_varnishLayer = SliLayer::create(
-      testFileDir + "v_valid_no_spp_tag.tif", "SomeCoolTitle", 0, 0);
+      (testFileDir / "v_valid_no_spp_tag.tif").string(), "SomeCoolTitle", 0, 0);
   test_varnishLayer->fillMetaFromTiff(8, 1);
   test_varnishLayer->fillBitmapFromTiff();
   Varnish::Ptr test_varnish = Varnish::create(test_varnishLayer);
   // Properties set correctly?
   BOOST_REQUIRE(test_varnish->layer->name == "SomeCoolTitle");
   BOOST_REQUIRE(test_varnish->layer->filepath ==
-                testFileDir + "v_valid_no_spp_tag.tif");
+                (testFileDir / "v_valid_no_spp_tag.tif").string());
   BOOST_REQUIRE(test_varnish->layer->width == 20);
   BOOST_REQUIRE(test_varnish->layer->height == 20);
   BOOST_REQUIRE(test_varnish->layer->xoffset == 0);
@@ -213,13 +210,13 @@ BOOST_AUTO_TEST_CASE(varnish_load_valid_tiff_no_spp_tag) {
 
 BOOST_AUTO_TEST_CASE(varnish_load_invalid_tiff) {
   SliLayer::Ptr test_varnishLayer =
-      SliLayer::create(testFileDir + "v_invalidrgb.tif", "Another Title", 0, 0);
+      SliLayer::create((testFileDir / "v_invalidrgb.tif").string(), "Another Title", 0, 0);
   // Tif handling should fail here
   BOOST_REQUIRE(!test_varnishLayer->fillMetaFromTiff(8, 1));
   // Properties set correctly?
   BOOST_REQUIRE(test_varnishLayer->name == "Another Title");
   BOOST_REQUIRE(test_varnishLayer->filepath ==
-                testFileDir + "v_invalidrgb.tif");
+                (testFileDir / "v_invalidrgb.tif").string());
   BOOST_REQUIRE(test_varnishLayer->width == 0);
   BOOST_REQUIRE(test_varnishLayer->height == 0);
   BOOST_REQUIRE(test_varnishLayer->xoffset == 0);
@@ -232,13 +229,13 @@ BOOST_AUTO_TEST_CASE(varnish_load_invalid_tiff) {
 BOOST_AUTO_TEST_CASE(varnish_load_zero_res_tiff) {
   // This test file is missinga width tag
   SliLayer::Ptr test_varnishLayer = SliLayer::create(
-      testFileDir + "v_invalid_no_width.tif", "Another Title", 0, 0);
+      (testFileDir / "v_invalid_no_width.tif").string(), "Another Title", 0, 0);
   // Tif handling should fail here
   BOOST_REQUIRE(!test_varnishLayer->fillMetaFromTiff(8, 1));
   // Properties set correctly?
   BOOST_REQUIRE(test_varnishLayer->name == "Another Title");
   BOOST_REQUIRE(test_varnishLayer->filepath ==
-                testFileDir + "v_invalid_no_width.tif");
+                (testFileDir / "v_invalid_no_width.tif").string());
   BOOST_REQUIRE(test_varnishLayer->width == 0);
   BOOST_REQUIRE(test_varnishLayer->height == 0);
   BOOST_REQUIRE(test_varnishLayer->xoffset == 0);
@@ -251,12 +248,12 @@ BOOST_AUTO_TEST_CASE(varnish_load_zero_res_tiff) {
 BOOST_AUTO_TEST_CASE(varnish_load_corrupted_tiff) {
   // This test files magic number and file data was randomly edited.
   SliLayer::Ptr test_varnishLayer =
-      SliLayer::create(testFileDir + "v_corrupted.tif", "Another Title", 0, 0);
+      SliLayer::create((testFileDir / "v_corrupted.tif").string(), "Another Title", 0, 0);
   // Tif handling should fail here
   BOOST_REQUIRE(!test_varnishLayer->fillMetaFromTiff(8, 1));
   // Properties set correctly?
   BOOST_REQUIRE(test_varnishLayer->name == "Another Title");
-  BOOST_REQUIRE(test_varnishLayer->filepath == testFileDir + "v_corrupted.tif");
+  BOOST_REQUIRE(test_varnishLayer->filepath == (testFileDir / "v_corrupted.tif").string());
   BOOST_REQUIRE(test_varnishLayer->width == 0);
   BOOST_REQUIRE(test_varnishLayer->height == 0);
   BOOST_REQUIRE(test_varnishLayer->xoffset == 0);
@@ -268,13 +265,13 @@ BOOST_AUTO_TEST_CASE(varnish_load_corrupted_tiff) {
 
 BOOST_AUTO_TEST_CASE(varnish_load_nonexistent_tiff) {
   SliLayer::Ptr test_varnishLayer = SliLayer::create(
-      testFileDir + "v_nonexistent.tif", "This file doesn't exist", 0, 0);
+      (testFileDir / "v_nonexistent.tif").string(), "This file doesn't exist", 0, 0);
   // Tif handling should fail here
   BOOST_REQUIRE(!test_varnishLayer->fillMetaFromTiff(8, 1));
   // Properties set correctly?
   BOOST_REQUIRE(test_varnishLayer->name == "This file doesn't exist");
   BOOST_REQUIRE(test_varnishLayer->filepath ==
-                testFileDir + "v_nonexistent.tif");
+                (testFileDir / "v_nonexistent.tif").string());
   BOOST_REQUIRE(test_varnishLayer->width == 0);
   BOOST_REQUIRE(test_varnishLayer->height == 0);
   BOOST_REQUIRE(test_varnishLayer->xoffset == 0);
@@ -287,13 +284,13 @@ BOOST_AUTO_TEST_CASE(varnish_load_nonexistent_tiff) {
 BOOST_AUTO_TEST_CASE(varnish_load_1bps_tiff) {
   // This test file has 1 bps, which is not supported
   SliLayer::Ptr test_varnishLayer = SliLayer::create(
-      testFileDir + "v_invalid1bps.tif", "TitleGoesHere", 0, 0);
+      (testFileDir / "v_invalid1bps.tif").string(), "TitleGoesHere", 0, 0);
   // Tif handling should fail here
   BOOST_REQUIRE(!test_varnishLayer->fillMetaFromTiff(8, 1));
   // Properties set correctly?
   BOOST_REQUIRE(test_varnishLayer->name == "TitleGoesHere");
   BOOST_REQUIRE(test_varnishLayer->filepath ==
-                testFileDir + "v_invalid1bps.tif");
+                (testFileDir / "v_invalid1bps.tif").string());
   BOOST_REQUIRE(test_varnishLayer->width == 0);
   BOOST_REQUIRE(test_varnishLayer->height == 0);
   BOOST_REQUIRE(test_varnishLayer->xoffset == 0);
@@ -306,13 +303,13 @@ BOOST_AUTO_TEST_CASE(varnish_load_invalid_no_bps_tiff) {
   // This test file doesn't have a bps tag, thus will default to 1 bps. 1bps is
   // not supported for varnish
   SliLayer::Ptr test_varnishLayer = SliLayer::create(
-      testFileDir + "v_invalid_no_bps_tag.tif", "TitleGoesHere", 0, 0);
+      (testFileDir / "v_invalid_no_bps_tag.tif").string(), "TitleGoesHere", 0, 0);
   // Tif handling should fail here
   BOOST_REQUIRE(!test_varnishLayer->fillMetaFromTiff(8, 1));
   // Properties set correctly?
   BOOST_REQUIRE(test_varnishLayer->name == "TitleGoesHere");
   BOOST_REQUIRE(test_varnishLayer->filepath ==
-                testFileDir + "v_invalid_no_bps_tag.tif");
+                (testFileDir / "v_invalid_no_bps_tag.tif").string());
   BOOST_REQUIRE(test_varnishLayer->width == 0);
   BOOST_REQUIRE(test_varnishLayer->height == 0);
   BOOST_REQUIRE(test_varnishLayer->xoffset == 0);


### PR DESCRIPTION
Updated tests to work under CMake.

Modified some test cases to use a global variable pointing to the test file directory and using a global fixture to initialize it.